### PR TITLE
Update default log level to info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo9/n9-node-log",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Logging node module based on Winston",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo9/n9-node-log",
-  "version": "2.7.0",
+  "version": "2.6.0",
   "description": "Logging node module based on Winston",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export class N9Log {
 		// Options
 		this.name = name
 		// tslint:disable-next-line:no-console
-		this.level = process.env.N9LOG || this.options.level || 'verbose'
+		this.level = process.env.N9LOG || this.options.level || 'info'
 		this.options.console = (typeof this.options.console === 'boolean' ? this.options.console : true)
 		this.options.formatJSON = (typeof this.options.formatJSON === 'boolean' ? this.options.formatJSON : false)
 		this.options.files = this.options.files || []


### PR DESCRIPTION
It seems strange to have a default log level to verbose. Any program that you use, by default have info logs. Only in specific cases you want to enable debug (in dev environments for instance).